### PR TITLE
Remove excessive hints from Challenge B materials

### DIFF
--- a/aws-setup/lambda-functions/sample-data-api/challenge-b-project/README.md
+++ b/aws-setup/lambda-functions/sample-data-api/challenge-b-project/README.md
@@ -37,37 +37,7 @@ main.js                    # Lambda handler - entry point
 
 ## 🔍 Debugging Tips
 
-### Primary Memory Leak Categories to Investigate:
-
-1. **Connection Pool Issues**
-   - Database connections not closed
-   - Redis client accumulation
-   - .NET interop resource disposal
-
-2. **Cache Memory Leaks**
-   - Unbounded cache growth
-   - Missing TTL/eviction policies
-   - Double caching (memory + Redis)
-
-3. **Event Listener Accumulation**
-   - Process event listeners
-   - Connection event handlers
-   - Timer callbacks
-
-4. **Data Structure Growth**
-   - Maps and Arrays that never shrink
-   - Historical data accumulation
-   - Error context storage
-
-5. **Circular References**
-   - Object reference cycles
-   - Parent-child relationships
-   - Closure captures
-
-6. **Timer/Interval Leaks**
-   - Intervals not cleared
-   - Timers creating closures
-   - Recursive timer patterns
+When investigating memory leaks in production systems, focus on systematic analysis of resource lifecycle patterns and data structure management.
 
 ## 🎯 Success Criteria
 
@@ -103,18 +73,6 @@ node --inspect main.js
 3. **Map data flow** between modules
 4. **Identify resource acquisition points** and their cleanup pairs
 5. **Look for missing cleanup in error paths**
-
-## 🔧 Expected Fixes Categories
-
-You should find and fix issues in these areas:
-- [ ] Connection pooling and cleanup
-- [ ] Cache size management and eviction
-- [ ] Event listener management
-- [ ] Timer/interval cleanup
-- [ ] Data structure bounds checking
-- [ ] Circular reference breaking
-- [ ] .NET resource disposal
-- [ ] Error handling resource cleanup
 
 ## ⏱️ Time Management
 

--- a/sample-data/legacy-api-docs.md
+++ b/sample-data/legacy-api-docs.md
@@ -28,30 +28,6 @@ SIGSEGV (Signal: Segmentation Violation)
 - Race condition in multi-threaded access
 ```
 
-#### Legacy API Connection Pattern
-
-```javascript
-// PROBLEMATIC PATTERN - DO NOT USE
-class LegacyApiClient {
-  constructor() {
-    this.connections = []; // Never cleaned!
-    this.dotNetFunction = edge.func({...});
-  }
-}
-
-// BETTER PATTERN
-class LegacyApiClient {
-  constructor() {
-    this.maxConnections = 10;
-    this.connectionPool = new ConnectionPool();
-  }
-  
-  async cleanup() {
-    await this.connectionPool.drain();
-  }
-}
-```
-
 ### GraphQL Resolver Best Practices
 
 - Always dispose of resources in finally blocks


### PR DESCRIPTION
## 🎯 Purpose

Remove answer spoilers from Challenge B that prevented proper evaluation of independent debugging skills vs AI-dependent problem solving.

## 🚨 Problem

Challenge B materials were providing complete answer keys:
- File descriptions revealed leak types ("# Unbounded cache issues")
- Code examples had inline comments pointing out exact leaks
- Complete taxonomy of all 6 memory leak categories
- Side-by-side before/after solution examples

This defeated the core evaluation criteria from `comprehensive-scoring-rubric.md`:
> **Evaluator Note:** Candidate must identify the connection array issue themselves

Candidates could read the hints and ask AI to implement each one without demonstrating any independent analysis.

## ✅ Changes Made

### challenges/challenge-b-debugging.md
- ✅ Remove leak type hints from project structure (lines 27-37)
- ✅ Remove "Look for patterns like" section (lines 54-59)
- ✅ Remove code examples with answer comments (lines 87-182)
- ✅ Remove exact leak count disclosure (line 193)

### challenge-b-project/README.md
- ✅ Remove complete memory leak taxonomy (lines 40-71)
- ✅ Remove "Expected Fixes Categories" checklist (lines 107-118)
- ✅ Keep general debugging guidance and symptoms

### sample-data/legacy-api-docs.md
- ✅ Remove side-by-side problematic vs better pattern code (lines 34-52)
- ✅ Keep error descriptions and general best practices

## 📊 Impact

**Before:** Candidates got complete answer keys
**After:** Candidates must independently:
1. Analyze code to identify issues
2. Determine root causes
3. Demonstrate debugging methodology
4. Use AI only after understanding problems

## ✅ What's Preserved

**Kept in materials:**
- Error symptoms and CloudWatch logs
- Lambda function access
- Project structure (neutral descriptions)
- General debugging advice
- Architecture overview

**Challenge A unchanged** (intentionally detailed to prompt discussion about idempotency, resumability, monitoring, etc.)

## 🔍 Testing

Verified that candidates still receive:
- All project files via setup script
- Complete error logs and symptoms
- General context and architecture
- But NO specific leak locations or types

Files with other changes (reset-interview.sh, generate-credentials-email.sh) intentionally excluded from this PR to preserve that work.

---

Fixes the mismatch between scoring rubric expectations and actual candidate materials.