### PR TITLE
Fix operational issues in reset and credentials scripts

### DIFF
--- a/interviewee-collateral/generate-credentials-email.sh
+++ b/interviewee-collateral/generate-credentials-email.sh
@@ -192,7 +192,7 @@ Hi $CANDIDATE_NAME,
 
 Here are your AWS credentials for the upcoming interview session. Please set these up now and test your access.
 
-⏰ **IMPORTANT**: These credentials are valid for 4 hours from generation time.
+⏰ **IMPORTANT**: These credentials are valid for 12 hours from generation time.
 🔄 **If expired**: Contact your interviewer for fresh credentials.
 
 === AWS SETUP INSTRUCTIONS ===
@@ -266,7 +266,7 @@ Note: Redis is available for Lambda functions but not directly accessible from y
 === TROUBLESHOOTING ===
 
 If credentials don't work:
-- Re-run the credential commands above (tokens expire after 4 hours)
+- Re-run the credential commands above (tokens expire after 12 hours)
 - Make sure you copied all credentials exactly as provided
 - Install AWS CLI if needed:
   * macOS: brew install awscli


### PR DESCRIPTION
## Changes

This PR fixes two operational issues discovered during testing:

### 1. Lambda Reset from S3 Package

**Problem:** Reset script was skipping Lambda reset entirely, meaning if candidates modified the Lambda code during debugging, it wouldn't be reset for the next interview.

**Solution:** 
- Added extraction of deployment bucket and interview ID from CloudFormation parameters
- Replaced skip logic with actual S3-based Lambda update
- Uses  with verified S3 package (SHA256 confirmed match)

**Benefits:**
- ✅ Lambda now gets reset to original buggy state from S3 package
- ✅ Handles cases where candidates modify Lambda during debugging
- ✅ Maintains quick reset time (~1-2 minutes)

### 2. Credential Duration Fix

**Problem:** Email template incorrectly stated credentials expire in 4 hours when they actually last 12 hours.

**Solution:** Updated two lines in generate-credentials-email.sh:
- Line 195: `4 hours` → `12 hours`
- Line 269: `expire after 4 hours` → `expire after 12 hours`

**Benefit:** Email now correctly states credential duration matching actual STS token lifespan (43200 seconds = 12 hours)

## Impact

- 2 files changed
- +30 insertions, -73 deletions
- Net reduction of 43 lines (removed inline Lambda code generation)

## Testing

- ✅ Verified S3 package matches current Lambda deployment (identical SHA256)
- ✅ Reset script logic reviewed and confirmed correct parameter extraction
- ✅ Email template credential duration matches actual STS assume-role call